### PR TITLE
Add portfolio MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,119 @@
+## Portfolio MCP server
+
+Run the local stdio MCP server:
+
+```bash
+uv run python -m src.mcp_server
+```
+
+Required environment:
+
+```text
+TRANSACTIONS_SHEET=your-google-sheet-id
+BUY_WORKSHEET=Buy
+SELL_WORKSHEET=Sell
+```
+
+Claude Desktop / Claude Code config shape:
+
+```json
+{
+  "mcpServers": {
+    "portfolio": {
+      "command": "/Users/somnath/.local/bin/uv",
+      "args": [
+        "--directory",
+        "/Users/somnath/code-projects/ai-portfolio",
+        "run",
+        "python",
+        "-m",
+        "src.mcp_server"
+      ],
+      "env": {
+        "TRANSACTIONS_SHEET": "your-google-sheet-id"
+      }
+    }
+  }
+}
+```
+
+Use `uv --directory` instead of relying on `cwd`; some desktop MCP launchers do
+not apply `cwd` before Python resolves local modules.
+
+## ChatGPT setup
+
+ChatGPT cannot launch this local `stdio` server directly. It needs a remote MCP
+URL over HTTPS. For quick personal testing, run the server locally with the SSE
+transport and expose it through a temporary HTTPS tunnel.
+
+Start the local MCP server:
+
+```bash
+PORTFOLIO_MCP_TRANSPORT=sse \
+PORTFOLIO_MCP_HOST=127.0.0.1 \
+PORTFOLIO_MCP_PORT=8000 \
+uv run python -m src.mcp_server
+```
+
+The local endpoint is:
+
+```text
+http://127.0.0.1:8000/sse
+```
+
+Expose it with a tunnel, for example ngrok:
+
+```bash
+ngrok http http://127.0.0.1:8000
+```
+
+If ngrok gives you:
+
+```text
+https://abc123.ngrok-free.app
+```
+
+then the ChatGPT MCP URL is:
+
+```text
+https://abc123.ngrok-free.app/sse
+```
+
+In ChatGPT web:
+
+1. Enable developer mode for MCP/custom apps in workspace or app settings.
+2. Create a custom app / MCP connector.
+3. Use the public tunnel URL ending in `/sse`.
+4. Choose SSE as the protocol.
+5. Use no authentication for short local testing only.
+6. Scan tools and verify these tools are discovered:
+   - `get_portfolio_snapshot`
+   - `get_positions`
+   - `get_position_detail`
+   - `get_transactions`
+   - `get_realized_positions`
+
+Example prompt:
+
+```text
+Use my portfolio app. Call get_portfolio_snapshot and summarize my current holdings by category.
+```
+
+Stop the tunnel when testing is complete. No-auth tunnel testing exposes portfolio
+data to anyone with the tunnel URL.
+
+For longer-term ChatGPT usage, deploy the MCP server behind HTTPS with proper
+OAuth-compatible authentication. The `streamable-http` endpoint is `/mcp`:
+
+```bash
+PORTFOLIO_MCP_TRANSPORT=streamable-http \
+PORTFOLIO_MCP_HOST=127.0.0.1 \
+PORTFOLIO_MCP_PORT=8000 \
+PORTFOLIO_MCP_PATH=/mcp \
+PORTFOLIO_MCP_AUTH_TOKEN=local-test-token \
+uv run python -m src.mcp_server
+```
+
+The current `streamable-http` mode uses a static bearer token, which is useful
+for local/API testing but is not the right final auth model for a published
+ChatGPT app.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "gspread>=6.2.1",
     "pytest>=8.3.4",
     "yfinance>=0.2.66",
+    "mcp[cli]>=1.27.2",
+    "pydantic>=2.13.4",
 ]
 
 

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""Portfolio MCP server package."""

--- a/src/mcp_server/__main__.py
+++ b/src/mcp_server/__main__.py
@@ -1,0 +1,11 @@
+from src.mcp_server.config import configure_logging
+from src.mcp_server.server import run_server
+
+
+def main() -> None:
+    configure_logging()
+    run_server()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server/config.py
+++ b/src/mcp_server/config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Literal
+
+Transport = Literal["stdio", "sse", "streamable-http"]
+
+
+@dataclass(frozen=True)
+class PortfolioMcpConfig:
+    transport: Transport = "stdio"
+    host: str = "127.0.0.1"
+    port: int = 8000
+    path: str = "/mcp"
+    auth_token: str | None = None
+
+
+def load_config() -> PortfolioMcpConfig:
+    transport = os.getenv("PORTFOLIO_MCP_TRANSPORT", "stdio")
+    if transport not in {"stdio", "sse", "streamable-http"}:
+        raise ValueError("PORTFOLIO_MCP_TRANSPORT must be stdio, sse, or streamable-http")
+
+    return PortfolioMcpConfig(
+        transport=transport,
+        host=os.getenv("PORTFOLIO_MCP_HOST", "127.0.0.1"),
+        port=int(os.getenv("PORTFOLIO_MCP_PORT", "8000")),
+        path=os.getenv("PORTFOLIO_MCP_PATH", "/mcp"),
+        auth_token=os.getenv("PORTFOLIO_MCP_AUTH_TOKEN"),
+    )
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )

--- a/src/mcp_server/schemas.py
+++ b/src/mcp_server/schemas.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class EnrichedPosition(StrictModel):
+    ticker: str
+    company: str | None
+    category: str | None
+    account: str | None
+    brokerage: str | None
+    qty: float
+    current_price: float | None
+    day_change_pct: float | None
+    day_change_value: float | None
+    average_cost: float | None
+    total_cost_basis: float
+    market_value: float | None
+    gain: float | None
+    gain_pct: float | None
+    change_7d_pct: float | None
+    change_1m_pct: float | None
+    change_3m_pct: float | None
+    change_6m_pct: float | None
+    change_1y_pct: float | None
+    transaction_count: int
+    first_buy_date: str | None
+    last_buy_date: str | None
+
+
+class PortfolioTotals(StrictModel):
+    total_cost_basis: float
+    market_value: float
+    gain: float
+    gain_pct: float | None
+    day_change_pct: float | None
+    day_change_value: float
+    position_count: int
+    transaction_count: int
+
+
+class Allocation(StrictModel):
+    key: str
+    total_cost_basis: float
+    market_value: float
+    allocation_pct: float | None
+    position_count: int
+
+
+class PortfolioSnapshotResponse(StrictModel):
+    as_of: str
+    source: Literal["buy_tab"]
+    totals: PortfolioTotals
+    positions: list[EnrichedPosition]
+    allocations: list[Allocation]
+    warnings: list[str] = Field(default_factory=list)
+
+
+class PositionsResponse(StrictModel):
+    as_of: str
+    source: Literal["buy_tab"]
+    positions: list[EnrichedPosition]
+    warnings: list[str] = Field(default_factory=list)
+
+
+class Transaction(StrictModel):
+    date: str | None
+    source: Literal["open_positions", "closed_positions"]
+    brokerage: str | None
+    account: str | None
+    category: str | None
+    company: str | None
+    ticker: str
+    action: Literal["Buy", "Sell"]
+    cost_basis_method: str | None
+    qty: float
+    price_per_share: float
+    total: float
+    row_number: int | None
+
+
+class TransactionsResponse(StrictModel):
+    transactions: list[Transaction]
+    result_count: int
+    truncated: bool
+    warnings: list[str] = Field(default_factory=list)
+
+
+class RealizedPosition(StrictModel):
+    ticker: str
+    company: str | None
+    category: str | None
+    qty_bought: float
+    qty_sold: float
+    is_quantity_matched: bool
+    cost_basis: float
+    proceeds: float
+    realized_gain: float
+    realized_gain_pct: float | None
+    first_buy_date: str | None
+    last_sell_date: str | None
+    transaction_count: int
+
+
+class RealizedPositionsResponse(StrictModel):
+    source: Literal["sell_tab"]
+    realized_positions: list[RealizedPosition]
+    warnings: list[str] = Field(default_factory=list)
+
+
+class PositionDetailResponse(StrictModel):
+    ticker: str
+    open_position: EnrichedPosition | None
+    open_transactions: list[Transaction]
+    closed_transactions: list[Transaction]
+    realized_position: RealizedPosition | None
+    warnings: list[str] = Field(default_factory=list)

--- a/src/mcp_server/schemas.py
+++ b/src/mcp_server/schemas.py
@@ -108,9 +108,32 @@ class RealizedPosition(StrictModel):
     transaction_count: int
 
 
+class ClosedPosition(StrictModel):
+    closed_position_id: str
+    ticker: str
+    company: str | None
+    category: str | None
+    close_date: str | None
+    qty_bought: float
+    qty_sold: float
+    is_quantity_matched: bool
+    cost_basis: float
+    proceeds: float
+    average_cost: float | None
+    sell_price: float | None
+    average_sell_price: float | None
+    realized_gain: float
+    realized_gain_pct: float | None
+    first_buy_date: str | None
+    buy_transaction_count: int
+    buy_row_numbers: list[int]
+    sell_row_number: int | None
+
+
 class RealizedPositionsResponse(StrictModel):
     source: Literal["sell_tab"]
-    realized_positions: list[RealizedPosition]
+    closed_positions: list[ClosedPosition]
+    aggregate_realized_positions: list[RealizedPosition] | None
     warnings: list[str] = Field(default_factory=list)
 
 
@@ -118,6 +141,7 @@ class PositionDetailResponse(StrictModel):
     ticker: str
     open_position: EnrichedPosition | None
     open_transactions: list[Transaction]
+    closed_positions: list[ClosedPosition]
     closed_transactions: list[Transaction]
-    realized_position: RealizedPosition | None
+    aggregate_realized_position: RealizedPosition | None
     warnings: list[str] = Field(default_factory=list)

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -11,6 +11,7 @@ from mcp.server.fastmcp import FastMCP
 from src import portfolio_data
 from src.mcp_server.config import PortfolioMcpConfig, load_config
 from src.mcp_server.schemas import (
+    ClosedPosition,
     EnrichedPosition,
     PortfolioSnapshotResponse,
     PositionDetailResponse,
@@ -97,14 +98,18 @@ def create_server(config: PortfolioMcpConfig | None = None) -> FastMCP:
     @mcp.tool()
     def get_position_detail(
         ticker: str,
-        include_closed_history: bool = True,
+        include_closed_positions: bool = True,
+        include_raw_transactions: bool = False,
+        include_aggregate: bool = True,
     ) -> dict:
-        """Return open position, raw transactions, and closed-history detail for one ticker."""
+        """Return current position context and summarized closed history for one ticker."""
 
         response = PositionDetailResponse.model_validate(
             portfolio_data.get_position_detail(
                 ticker=ticker,
-                include_closed_history=include_closed_history,
+                include_closed_positions=include_closed_positions,
+                include_raw_transactions=include_raw_transactions,
+                include_aggregate=include_aggregate,
             )
         )
         return response.model_dump(mode="json")
@@ -139,11 +144,17 @@ def create_server(config: PortfolioMcpConfig | None = None) -> FastMCP:
         return response.model_dump(mode="json")
 
     @mcp.tool()
-    def get_realized_positions(ticker: str | None = None) -> dict:
-        """Return closed-position summaries computed from the Sell tab."""
+    def get_realized_positions(
+        ticker: str | None = None,
+        include_aggregate: bool = True,
+    ) -> dict:
+        """Return one closed-position summary per Sell row from the Sell tab."""
 
         response = RealizedPositionsResponse.model_validate(
-            portfolio_data.get_realized_positions(ticker=ticker)
+            portfolio_data.get_realized_positions(
+                ticker=ticker,
+                include_aggregate=include_aggregate,
+            )
         )
         return response.model_dump(mode="json")
 
@@ -158,6 +169,12 @@ def create_server(config: PortfolioMcpConfig | None = None) -> FastMCP:
         """Return the JSON schema for enriched current positions."""
 
         return json.dumps(EnrichedPosition.model_json_schema(), indent=2)
+
+    @mcp.resource("portfolio://schema/closed_positions")
+    def closed_positions_schema() -> str:
+        """Return the JSON schema for closed-position/disposal summaries."""
+
+        return json.dumps(ClosedPosition.model_json_schema(), indent=2)
 
     return mcp
 

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import hmac
+import json
+from typing import Literal
+
+from mcp.server.auth.provider import AccessToken
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.fastmcp import FastMCP
+
+from src import portfolio_data
+from src.mcp_server.config import PortfolioMcpConfig, load_config
+from src.mcp_server.schemas import (
+    EnrichedPosition,
+    PortfolioSnapshotResponse,
+    PositionDetailResponse,
+    PositionsResponse,
+    RealizedPositionsResponse,
+    Transaction,
+    TransactionsResponse,
+)
+
+
+class StaticTokenVerifier:
+    def __init__(self, token: str):
+        self._token = token
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not hmac.compare_digest(token, self._token):
+            return None
+        return AccessToken(
+            token=token,
+            client_id="portfolio-mcp",
+            scopes=["portfolio:read"],
+        )
+
+
+def create_server(config: PortfolioMcpConfig | None = None) -> FastMCP:
+    config = config or load_config()
+    auth_settings = None
+    token_verifier = None
+    if config.transport == "streamable-http":
+        if not config.auth_token:
+            raise ValueError("PORTFOLIO_MCP_AUTH_TOKEN is required for streamable-http")
+        base_url = f"http://{config.host}:{config.port}"
+        auth_settings = AuthSettings(
+            issuer_url=base_url,
+            resource_server_url=base_url,
+            required_scopes=["portfolio:read"],
+        )
+        token_verifier = StaticTokenVerifier(config.auth_token)
+
+    mcp = FastMCP(
+        "portfolio",
+        instructions=(
+            "Read-only access to the owner's portfolio holdings, transaction "
+            "history, and realized-position summaries."
+        ),
+        host=config.host,
+        port=config.port,
+        streamable_http_path=config.path,
+        log_level="ERROR",
+        auth=auth_settings,
+        token_verifier=token_verifier,
+    )
+
+    @mcp.tool()
+    def get_portfolio_snapshot(
+        group_by: Literal["ticker", "category", "account", "brokerage"] = "ticker",
+    ) -> dict:
+        """Return a dashboard-equivalent current portfolio summary."""
+
+        response = PortfolioSnapshotResponse.model_validate(
+            portfolio_data.get_portfolio_snapshot(group_by=group_by)
+        )
+        return response.model_dump(mode="json")
+
+    @mcp.tool()
+    def get_positions(
+        ticker: str | None = None,
+        category: str | None = None,
+        account: str | None = None,
+        brokerage: str | None = None,
+    ) -> dict:
+        """Return enriched current/open positions, optionally filtered."""
+
+        response = PositionsResponse.model_validate(
+            portfolio_data.get_positions(
+                ticker=ticker,
+                category=category,
+                account=account,
+                brokerage=brokerage,
+            )
+        )
+        return response.model_dump(mode="json")
+
+    @mcp.tool()
+    def get_position_detail(
+        ticker: str,
+        include_closed_history: bool = True,
+    ) -> dict:
+        """Return open position, raw transactions, and closed-history detail for one ticker."""
+
+        response = PositionDetailResponse.model_validate(
+            portfolio_data.get_position_detail(
+                ticker=ticker,
+                include_closed_history=include_closed_history,
+            )
+        )
+        return response.model_dump(mode="json")
+
+    @mcp.tool()
+    def get_transactions(
+        ticker: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        account: str | None = None,
+        brokerage: str | None = None,
+        category: str | None = None,
+        source: Literal["open_positions", "closed_positions", "all"] = "all",
+        action: Literal["Buy", "Sell", "all"] = "all",
+        limit: int = 500,
+    ) -> dict:
+        """Return normalized raw transactions from the Buy tab, Sell tab, or both."""
+
+        response = TransactionsResponse.model_validate(
+            portfolio_data.get_transactions(
+                ticker=ticker,
+                start_date=start_date,
+                end_date=end_date,
+                account=account,
+                brokerage=brokerage,
+                category=category,
+                source=source,
+                action=action,
+                limit=limit,
+            )
+        )
+        return response.model_dump(mode="json")
+
+    @mcp.tool()
+    def get_realized_positions(ticker: str | None = None) -> dict:
+        """Return closed-position summaries computed from the Sell tab."""
+
+        response = RealizedPositionsResponse.model_validate(
+            portfolio_data.get_realized_positions(ticker=ticker)
+        )
+        return response.model_dump(mode="json")
+
+    @mcp.resource("portfolio://schema/transactions")
+    def transactions_schema() -> str:
+        """Return the JSON schema for normalized transaction rows."""
+
+        return json.dumps(Transaction.model_json_schema(), indent=2)
+
+    @mcp.resource("portfolio://schema/positions")
+    def positions_schema() -> str:
+        """Return the JSON schema for enriched current positions."""
+
+        return json.dumps(EnrichedPosition.model_json_schema(), indent=2)
+
+    return mcp
+
+
+def run_server() -> None:
+    config = load_config()
+    server = create_server(config)
+    server.run(config.transport)

--- a/src/portfolio.py
+++ b/src/portfolio.py
@@ -2,100 +2,62 @@
 # author: somnath.banerjee
 #
 
-# system
-
-# first-party
-from src.config.ColumnNameConsts import ColumnNames
-from src.util.gspread import transactions
-from src.util.gspread import update_portfolio_summary
-from src.util.yfinance import curr_price
-
-# third-party
-from src.util.historical_cache import get_historical_prices
 import pandas as pd
 
-
-CN = ColumnNames
+from src.config.ColumnNameConsts import ColumnNames as CN
+from src.portfolio_data import get_enriched_open_positions
+from src.util.gspread import update_portfolio_summary
 
 
 def load():
-    t = transactions()
-    h = t.groupby(["Category", "Company", "Ticker"])[["Qty", "Total"]].sum()
-    h[CN.COST_PRICE] = h[CN.TOTAL] / h[CN.QTY]
-
-    stocks = h.iloc[h.index.get_level_values("Category") != "Cryptocurrency"]
-    cryptos = h.iloc[h.index.get_level_values("Category") == "Cryptocurrency"]
-    # stocks = stocks[3:6] # only for debugging
-
-    stock_prices = curr_price(stocks.index.get_level_values("Ticker"))
-    crypto_prices = curr_price(cryptos.index.get_level_values("Ticker"), crypto=True)
-
-    p = pd.concat([stock_prices, crypto_prices])
-    h = h.join(p, on="Ticker", how="inner")
-    h = h.set_index(h.index.droplevel(["Category"]))
-    h.reset_index(inplace=True)
-
-    if not h[h[CN.PRICE].isnull()].empty:
-        null_tickers = h[h[CN.PRICE].isnull()][CN.TICKER].values
-        print("Discarding null prices: " + ", ".join(null_tickers))
-        h = h.dropna(axis=0)
-
-    return h
+    enriched = get_enriched_open_positions()
+    return _positions_to_dataframe(enriched["positions"])
 
 
 def summary():
-    s = load()
-
-    s[CN.MARKET_VALUE] = s[CN.QTY] * s[CN.PRICE]
-    
-    # Calculate historical changes
-    hist_prices = get_historical_prices(s[CN.TICKER].unique().tolist())
-    
-    # Add historical changes
-    for period, col_name in [
-        ("7D", CN.CHNG_7D), 
-        ("1M", CN.CHNG_1M), 
-        ("3M", CN.CHNG_3M), 
-        ("6M", CN.CHNG_6M), 
-        ("1Y", CN.CHNG_1Y)
-    ]:
-        s[col_name] = s.apply(
-            lambda row: (
-                (row[CN.PRICE] - hist_prices.get(row[CN.TICKER], {}).get(period)) 
-                / hist_prices.get(row[CN.TICKER], {}).get(period) * 100
-            ) if hist_prices.get(row[CN.TICKER], {}).get(period) else None, 
-            axis=1
-        )
-
-    s[CN.DAY_CHNG_VAL] = s[CN.MARKET_VALUE] * s[CN.DAY_CHNG] / (1 + s[CN.DAY_CHNG])
-
-    s[CN.DAY_CHNG] = 100 * s[CN.DAY_CHNG]
-    s[CN.GAIN] = s[CN.MARKET_VALUE] - s[CN.TOTAL]
-    s[CN.GAIN_PCT] = 100 * s[CN.GAIN] / s[CN.TOTAL]
-
-    t = s.sum()
-    t = t[[CN.TOTAL, CN.MARKET_VALUE, CN.DAY_CHNG_VAL]]
-    t[CN.GAIN] = t[CN.MARKET_VALUE] - t[CN.TOTAL]
-    t[CN.GAIN_PCT] = 100 * t[CN.GAIN] / t[CN.TOTAL]
-    t[CN.DAY_CHNG] = (
-        100 * t[CN.DAY_CHNG_VAL] / (t[CN.MARKET_VALUE] - t[CN.DAY_CHNG_VAL])
-    )
-    t = t[
-        [CN.TOTAL, CN.MARKET_VALUE, CN.GAIN, CN.GAIN_PCT, CN.DAY_CHNG, CN.DAY_CHNG_VAL]
-    ]
-    t = t.to_frame().T
+    enriched = get_enriched_open_positions()
+    s = _positions_to_dataframe(enriched["positions"])
+    t = _totals_to_dataframe(enriched["positions"])
 
     formatted_t = t.copy()
-    formatted_t[CN.TOTAL] = formatted_t[CN.TOTAL].apply(lambda x: f"${x:,.0f}")
-    formatted_t[CN.MARKET_VALUE] = formatted_t[CN.MARKET_VALUE].apply(lambda x: f"${x:,.0f}")
-    formatted_t[CN.GAIN] = formatted_t[CN.GAIN].apply(lambda x: f"${x:,.0f}")
-    formatted_t[CN.DAY_CHNG_VAL] = formatted_t[CN.DAY_CHNG_VAL].apply(lambda x: f"${x:,.0f}")
+    for column in [CN.TOTAL, CN.MARKET_VALUE, CN.GAIN, CN.DAY_CHNG_VAL]:
+        formatted_t[column] = formatted_t[column].apply(lambda x: f"${x:,.0f}")
 
-    formatted_t[CN.GAIN_PCT] = formatted_t[CN.GAIN_PCT].apply(lambda x: f"{x:.2f}%")
-    formatted_t[CN.DAY_CHNG] = formatted_t[CN.DAY_CHNG].apply(lambda x: f"{x:.2f}%")
+    for column in [CN.GAIN_PCT, CN.DAY_CHNG]:
+        formatted_t[column] = formatted_t[column].apply(lambda x: f"{x:.2f}%")
 
-    s = s[
+    try:
+        update_portfolio_summary(t)
+    except Exception as e:
+        print(f"Warning: Failed to save data to Google Sheets: {e}")
+
+    return s, formatted_t
+
+
+def _positions_to_dataframe(positions):
+    s = pd.DataFrame(
         [
+            {
+                CN.NAME: pos["company"],
+                CN.TICKER: pos["ticker"],
+                CN.PRICE: pos["current_price"],
+                CN.QTY: pos["qty"],
+                CN.DAY_CHNG: pos["day_change_pct"],
+                CN.DAY_CHNG_VAL: pos["day_change_value"],
+                CN.COST_PRICE: pos["average_cost"],
+                CN.TOTAL: pos["total_cost_basis"],
+                CN.MARKET_VALUE: pos["market_value"],
+                CN.GAIN_PCT: pos["gain_pct"],
+                CN.GAIN: pos["gain"],
+                CN.CHNG_7D: pos["change_7d_pct"],
+                CN.CHNG_1M: pos["change_1m_pct"],
+                CN.CHNG_3M: pos["change_3m_pct"],
+                CN.CHNG_6M: pos["change_6m_pct"],
+                CN.CHNG_1Y: pos["change_1y_pct"],
+            }
+            for pos in positions
+        ],
+        columns=[
             CN.NAME,
             CN.TICKER,
             CN.PRICE,
@@ -112,15 +74,50 @@ def summary():
             CN.CHNG_3M,
             CN.CHNG_6M,
             CN.CHNG_1Y,
-        ]
-    ]
-    s = s.astype({CN.TOTAL: int, CN.MARKET_VALUE: int, CN.GAIN: int})
-    s = s.round(2)
-    s = s.sort_values(CN.DAY_CHNG, ascending=False)
+        ],
+    )
 
-    try:
-        update_portfolio_summary(t)
-    except Exception as e:
-        print(f"Warning: Failed to save data to Google Sheets: {e}")
-    
-    return s, formatted_t
+    if s.empty:
+        return s
+
+    money_columns = [CN.TOTAL, CN.MARKET_VALUE, CN.GAIN]
+    s[money_columns] = s[money_columns].round(0).astype("Int64")
+    s = s.round(2)
+    return s.sort_values(CN.DAY_CHNG, ascending=False, na_position="last")
+
+
+def _totals_to_dataframe(positions):
+    total_cost_basis = sum(pos["total_cost_basis"] or 0 for pos in positions)
+    priced_cost_basis = sum(
+        pos["total_cost_basis"] or 0 for pos in positions if pos["market_value"] is not None
+    )
+    market_value = sum(pos["market_value"] or 0 for pos in positions)
+    gain = sum(pos["gain"] or 0 for pos in positions)
+    day_change_value = sum(pos["day_change_value"] or 0 for pos in positions)
+    previous_market_value = market_value - day_change_value
+
+    gain_pct = 100 * gain / priced_cost_basis if priced_cost_basis else 0
+    day_change_pct = (
+        100 * day_change_value / previous_market_value if previous_market_value else 0
+    )
+
+    return pd.DataFrame(
+        [
+            {
+                CN.TOTAL: total_cost_basis,
+                CN.MARKET_VALUE: market_value,
+                CN.GAIN: gain,
+                CN.GAIN_PCT: gain_pct,
+                CN.DAY_CHNG: day_change_pct,
+                CN.DAY_CHNG_VAL: day_change_value,
+            }
+        ],
+        columns=[
+            CN.TOTAL,
+            CN.MARKET_VALUE,
+            CN.GAIN,
+            CN.GAIN_PCT,
+            CN.DAY_CHNG,
+            CN.DAY_CHNG_VAL,
+        ],
+    )

--- a/src/portfolio_data.py
+++ b/src/portfolio_data.py
@@ -1,0 +1,700 @@
+from __future__ import annotations
+
+import os
+from collections import Counter, defaultdict
+from datetime import date
+from typing import Any, Literal
+
+import pandas as pd
+
+from src.config.ColumnNameConsts import ColumnNames as CN
+from src.util.gspread import worksheet_values
+from src.util.historical_cache import get_historical_prices
+from src.util.yfinance import curr_price
+
+SourceName = Literal["open_positions", "closed_positions"]
+
+BUY_WORKSHEET = "Buy"
+SELL_WORKSHEET = "Sell"
+SOURCE_OPEN: SourceName = "open_positions"
+SOURCE_CLOSED: SourceName = "closed_positions"
+
+EXPECTED_COLUMNS = [
+    "Date",
+    "Brokerage",
+    "Account",
+    "Category",
+    "Company",
+    "Ticker",
+    "Action",
+    "Cost Basis Method",
+    CN.QTY,
+    CN.COST_PRICE,
+    CN.TOTAL,
+]
+
+TRANSACTION_KEYS = [
+    "date",
+    "source",
+    "brokerage",
+    "account",
+    "category",
+    "company",
+    "ticker",
+    "action",
+    "cost_basis_method",
+    "qty",
+    "price_per_share",
+    "total",
+    "row_number",
+]
+
+
+def load_buy_transactions() -> dict[str, Any]:
+    return _load_tab(
+        worksheet_name=os.getenv("BUY_WORKSHEET", BUY_WORKSHEET),
+        worksheet_index=0,
+        source=SOURCE_OPEN,
+    )
+
+
+def load_sell_transactions() -> dict[str, Any]:
+    return _load_tab(
+        worksheet_name=os.getenv("SELL_WORKSHEET", SELL_WORKSHEET),
+        worksheet_index=None,
+        source=SOURCE_CLOSED,
+    )
+
+
+def get_enriched_open_positions() -> dict[str, Any]:
+    loaded = load_buy_transactions()
+    warnings = list(loaded["warnings"])
+    transactions = loaded["transactions"]
+    buy_transactions = [tx for tx in transactions if tx["action"] == "Buy"]
+
+    positions = []
+    by_ticker: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for tx in buy_transactions:
+        by_ticker[tx["ticker"]].append(tx)
+
+    price_data, price_warnings = _load_current_prices(by_ticker)
+    warnings.extend(price_warnings)
+
+    tickers = sorted(by_ticker)
+    try:
+        historical_prices = get_historical_prices(tickers) if tickers else {}
+    except Exception as exc:
+        historical_prices = {}
+        warnings.append(f"Historical price lookup failed: {exc}")
+
+    for ticker in tickers:
+        rows = by_ticker[ticker]
+        qty = sum(tx["qty"] for tx in rows)
+        total_cost_basis = sum(tx["total"] for tx in rows)
+        average_cost = _divide(total_cost_basis, qty)
+
+        current_price = price_data.get(ticker, {}).get("current_price")
+        day_change_decimal = price_data.get(ticker, {}).get("day_change_decimal")
+
+        if current_price is None:
+            warnings.append(f"Current price unavailable for {ticker}.")
+            day_change_pct = None
+            day_change_value = None
+            market_value = None
+            gain = None
+            gain_pct = None
+        else:
+            market_value = qty * current_price
+            gain = market_value - total_cost_basis
+            gain_pct = _pct(gain, total_cost_basis)
+            day_change_pct = None if day_change_decimal is None else day_change_decimal * 100
+            day_change_value = _day_change_value(market_value, day_change_decimal)
+
+        position = {
+            "ticker": ticker,
+            "company": _representative_value(rows, "company"),
+            "category": _representative_value(rows, "category"),
+            "account": _representative_value(rows, "account"),
+            "brokerage": _representative_value(rows, "brokerage"),
+            "qty": _json_number(qty),
+            "current_price": _json_number(current_price),
+            "day_change_pct": _json_number(day_change_pct),
+            "day_change_value": _json_number(day_change_value),
+            "average_cost": _json_number(average_cost),
+            "total_cost_basis": _json_number(total_cost_basis),
+            "market_value": _json_number(market_value),
+            "gain": _json_number(gain),
+            "gain_pct": _json_number(gain_pct),
+            "change_7d_pct": _historical_change(current_price, historical_prices, ticker, "7D"),
+            "change_1m_pct": _historical_change(current_price, historical_prices, ticker, "1M"),
+            "change_3m_pct": _historical_change(current_price, historical_prices, ticker, "3M"),
+            "change_6m_pct": _historical_change(current_price, historical_prices, ticker, "6M"),
+            "change_1y_pct": _historical_change(current_price, historical_prices, ticker, "1Y"),
+            "transaction_count": len(rows),
+            "first_buy_date": _min_date(rows),
+            "last_buy_date": _max_date(rows),
+        }
+        positions.append(position)
+
+    positions.sort(key=lambda pos: (pos["day_change_pct"] is None, -(pos["day_change_pct"] or 0)))
+    return {
+        "as_of": date.today().isoformat(),
+        "source": "buy_tab",
+        "positions": positions,
+        "transaction_count": len(transactions),
+        "warnings": _unique_warnings(warnings),
+    }
+
+
+def get_portfolio_snapshot(group_by: str = "ticker") -> dict[str, Any]:
+    if group_by not in {"ticker", "category", "account", "brokerage"}:
+        raise ValueError("group_by must be one of ticker, category, account, or brokerage")
+
+    enriched = get_enriched_open_positions()
+    positions = enriched["positions"]
+    totals = _portfolio_totals(positions, enriched["transaction_count"])
+    allocations = _allocations(positions, group_by)
+
+    return {
+        "as_of": enriched["as_of"],
+        "source": "buy_tab",
+        "totals": totals,
+        "positions": positions,
+        "allocations": allocations,
+        "warnings": enriched["warnings"],
+    }
+
+
+def get_positions(
+    ticker: str | None = None,
+    category: str | None = None,
+    account: str | None = None,
+    brokerage: str | None = None,
+) -> dict[str, Any]:
+    enriched = get_enriched_open_positions()
+    positions = [
+        pos
+        for pos in enriched["positions"]
+        if _matches(pos["ticker"], ticker, ticker=True)
+        and _matches(pos["category"], category)
+        and _matches(pos["account"], account)
+        and _matches(pos["brokerage"], brokerage)
+    ]
+
+    return {
+        "as_of": enriched["as_of"],
+        "source": "buy_tab",
+        "positions": positions,
+        "warnings": enriched["warnings"],
+    }
+
+
+def get_position_detail(ticker: str, include_closed_history: bool = True) -> dict[str, Any]:
+    normalized_ticker = _normalize_ticker(ticker)
+    warnings: list[str] = []
+    positions_result = get_positions(ticker=normalized_ticker)
+    warnings.extend(positions_result["warnings"])
+    open_position = positions_result["positions"][0] if positions_result["positions"] else None
+
+    open_transactions_result = get_transactions(source=SOURCE_OPEN, ticker=normalized_ticker)
+    warnings.extend(open_transactions_result["warnings"])
+
+    closed_transactions: list[dict[str, Any]] = []
+    realized_position = None
+    if include_closed_history:
+        closed_transactions_result = get_transactions(source=SOURCE_CLOSED, ticker=normalized_ticker)
+        warnings.extend(closed_transactions_result["warnings"])
+        closed_transactions = closed_transactions_result["transactions"]
+
+        realized_result = get_realized_positions(ticker=normalized_ticker)
+        warnings.extend(realized_result["warnings"])
+        if realized_result["realized_positions"]:
+            realized_position = realized_result["realized_positions"][0]
+
+    return {
+        "ticker": normalized_ticker,
+        "open_position": open_position,
+        "open_transactions": open_transactions_result["transactions"],
+        "closed_transactions": closed_transactions,
+        "realized_position": realized_position,
+        "warnings": _unique_warnings(warnings),
+    }
+
+
+def get_transactions(
+    ticker: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    account: str | None = None,
+    brokerage: str | None = None,
+    category: str | None = None,
+    source: Literal["open_positions", "closed_positions", "all"] = "all",
+    action: Literal["Buy", "Sell", "all"] = "all",
+    limit: int = 500,
+) -> dict[str, Any]:
+    if source not in {"open_positions", "closed_positions", "all"}:
+        raise ValueError("source must be open_positions, closed_positions, or all")
+    if action not in {"Buy", "Sell", "all"}:
+        raise ValueError("action must be Buy, Sell, or all")
+
+    warnings: list[str] = []
+    transactions: list[dict[str, Any]] = []
+    if source in {SOURCE_OPEN, "all"}:
+        loaded = load_buy_transactions()
+        warnings.extend(loaded["warnings"])
+        transactions.extend(loaded["transactions"])
+    if source in {SOURCE_CLOSED, "all"}:
+        loaded = load_sell_transactions()
+        warnings.extend(loaded["warnings"])
+        transactions.extend(loaded["transactions"])
+
+    start = _parse_filter_date(start_date, "start_date", warnings)
+    end = _parse_filter_date(end_date, "end_date", warnings)
+    normalized_ticker = _normalize_ticker(ticker) if ticker else None
+
+    filtered = []
+    for tx in transactions:
+        tx_date = tx["date"]
+        if normalized_ticker and tx["ticker"] != normalized_ticker:
+            continue
+        if action != "all" and tx["action"] != action:
+            continue
+        if not _matches(tx["account"], account):
+            continue
+        if not _matches(tx["brokerage"], brokerage):
+            continue
+        if not _matches(tx["category"], category):
+            continue
+        if start and (tx_date is None or tx_date < start):
+            continue
+        if end and (tx_date is None or tx_date > end):
+            continue
+        filtered.append(tx)
+
+    filtered.sort(
+        key=lambda tx: (
+            tx["date"] is None,
+            tx["date"] or "",
+            tx["source"],
+            tx["row_number"] or 0,
+        )
+    )
+
+    safe_limit = max(1, min(int(limit or 500), 5000))
+    truncated = len(filtered) > safe_limit
+    limited = filtered[:safe_limit]
+
+    return {
+        "transactions": [_transaction_view(tx) for tx in limited],
+        "result_count": len(limited),
+        "truncated": truncated,
+        "warnings": _unique_warnings(warnings),
+    }
+
+
+def get_realized_positions(ticker: str | None = None) -> dict[str, Any]:
+    loaded = load_sell_transactions()
+    warnings = list(loaded["warnings"])
+    normalized_ticker = _normalize_ticker(ticker) if ticker else None
+    transactions = [
+        tx
+        for tx in loaded["transactions"]
+        if normalized_ticker is None or tx["ticker"] == normalized_ticker
+    ]
+
+    by_ticker: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for tx in transactions:
+        by_ticker[tx["ticker"]].append(tx)
+
+    realized_positions = []
+    for tx_ticker in sorted(by_ticker):
+        rows = by_ticker[tx_ticker]
+        buy_rows = [tx for tx in rows if tx["action"] == "Buy"]
+        sell_rows = [tx for tx in rows if tx["action"] == "Sell"]
+
+        qty_bought = sum(tx["qty"] for tx in buy_rows)
+        qty_sold = sum(tx["qty"] for tx in sell_rows)
+        cost_basis = sum(tx["total"] for tx in buy_rows)
+        proceeds = sum(tx["total"] for tx in sell_rows)
+        realized_gain = proceeds - cost_basis
+        is_quantity_matched = abs(qty_bought - qty_sold) < 0.000001
+
+        if not is_quantity_matched:
+            warnings.append(
+                f"Sell tab quantity mismatch for {tx_ticker}: bought {qty_bought}, sold {qty_sold}."
+            )
+
+        realized_positions.append(
+            {
+                "ticker": tx_ticker,
+                "company": _representative_value(rows, "company"),
+                "category": _representative_value(rows, "category"),
+                "qty_bought": _json_number(qty_bought),
+                "qty_sold": _json_number(qty_sold),
+                "is_quantity_matched": is_quantity_matched,
+                "cost_basis": _json_number(cost_basis),
+                "proceeds": _json_number(proceeds),
+                "realized_gain": _json_number(realized_gain),
+                "realized_gain_pct": _json_number(_pct(realized_gain, cost_basis)),
+                "first_buy_date": _min_date(buy_rows),
+                "last_sell_date": _max_date(sell_rows),
+                "transaction_count": len(rows),
+            }
+        )
+
+    return {
+        "source": "sell_tab",
+        "realized_positions": realized_positions,
+        "warnings": _unique_warnings(warnings),
+    }
+
+
+def _load_tab(
+    worksheet_name: str,
+    worksheet_index: int | None,
+    source: SourceName,
+) -> dict[str, Any]:
+    warnings: list[str] = []
+    try:
+        values = worksheet_values(
+            worksheet_name=worksheet_name,
+            worksheet_index=worksheet_index,
+        )
+    except Exception as exc:
+        return {
+            "transactions": [],
+            "warnings": [f"Unable to read {worksheet_name} worksheet: {exc}"],
+        }
+
+    if not values:
+        return {
+            "transactions": [],
+            "warnings": [f"{worksheet_name} worksheet is empty."],
+        }
+
+    headers = [_clean_header(header) for header in values[0]]
+    if "Price per share" in headers and CN.COST_PRICE not in headers:
+        headers = [CN.COST_PRICE if header == "Price per share" else header for header in headers]
+
+    rows = []
+    for offset, row in enumerate(values[1:], start=2):
+        padded = row + [""] * max(0, len(headers) - len(row))
+        rows.append(dict(zip(headers, padded, strict=False)) | {"row_number": offset})
+
+    present = set(headers)
+    for column in EXPECTED_COLUMNS:
+        if column not in present:
+            warnings.append(f"{worksheet_name} worksheet is missing column '{column}'.")
+
+    transactions = []
+    for raw in rows:
+        tx = _normalize_transaction(raw, source, worksheet_name, warnings)
+        if tx:
+            transactions.append(tx)
+
+    return {
+        "transactions": transactions,
+        "warnings": _unique_warnings(warnings),
+    }
+
+
+def _normalize_transaction(
+    raw: dict[str, Any],
+    source: SourceName,
+    worksheet_name: str,
+    warnings: list[str],
+) -> dict[str, Any] | None:
+    row_number = raw.get("row_number")
+    ticker = _normalize_ticker(raw.get(CN.TICKER))
+    if not ticker:
+        warnings.append(f"{worksheet_name} row {row_number} has a blank ticker and was skipped.")
+        return None
+
+    action = _clean_string(raw.get("Action"))
+    if not action and source == SOURCE_OPEN:
+        action = "Buy"
+    elif action:
+        action = action.strip().title()
+
+    if action not in {"Buy", "Sell"}:
+        warnings.append(
+            f"{worksheet_name} row {row_number} has unsupported action '{raw.get('Action')}' and was skipped."
+        )
+        return None
+
+    date_value = _normalize_date(raw.get("Date"), worksheet_name, row_number, warnings)
+    qty = _normalize_number(raw.get(CN.QTY), CN.QTY, worksheet_name, row_number, warnings)
+    price = _normalize_number(
+        raw.get(CN.COST_PRICE),
+        CN.COST_PRICE,
+        worksheet_name,
+        row_number,
+        warnings,
+    )
+    total = _normalize_number(raw.get(CN.TOTAL), CN.TOTAL, worksheet_name, row_number, warnings)
+
+    if price == 0 and qty:
+        price = _divide(total, qty) or 0
+    if total == 0 and qty and price:
+        total = qty * price
+
+    return {
+        "date": date_value,
+        "source": source,
+        "brokerage": _clean_string(raw.get("Brokerage")),
+        "account": _clean_string(raw.get("Account")),
+        "category": _clean_string(raw.get("Category")),
+        "company": _clean_string(raw.get(CN.NAME)),
+        "ticker": ticker,
+        "action": action,
+        "cost_basis_method": _clean_string(raw.get("Cost Basis Method")),
+        "qty": _json_number(qty) or 0,
+        "price_per_share": _json_number(price) or 0,
+        "total": _json_number(total) or 0,
+        "row_number": row_number,
+    }
+
+
+def _load_current_prices(by_ticker: dict[str, list[dict[str, Any]]]) -> tuple[dict[str, Any], list[str]]:
+    warnings: list[str] = []
+    price_data: dict[str, Any] = {}
+    stock_tickers = []
+    crypto_tickers = []
+    for ticker, rows in by_ticker.items():
+        if _representative_value(rows, "category") == "Cryptocurrency":
+            crypto_tickers.append(ticker)
+        else:
+            stock_tickers.append(ticker)
+
+    for tickers, crypto in [(stock_tickers, False), (crypto_tickers, True)]:
+        if not tickers:
+            continue
+        try:
+            prices = curr_price(tickers, crypto=crypto)
+        except Exception as exc:
+            warnings.append(f"Current price lookup failed for {', '.join(tickers)}: {exc}")
+            continue
+
+        if prices is None or prices.empty:
+            warnings.append(f"Current price lookup returned no data for {', '.join(tickers)}.")
+            continue
+
+        for ticker in tickers:
+            if ticker not in prices.index:
+                continue
+            current_price = _json_number(prices.loc[ticker].get(CN.PRICE))
+            day_change = _json_number(prices.loc[ticker].get(CN.DAY_CHNG))
+            if current_price is None or current_price <= 0:
+                continue
+            price_data[ticker] = {
+                "current_price": current_price,
+                "day_change_decimal": day_change,
+            }
+
+    return price_data, warnings
+
+
+def _portfolio_totals(positions: list[dict[str, Any]], transaction_count: int) -> dict[str, Any]:
+    total_cost_basis = sum(pos["total_cost_basis"] or 0 for pos in positions)
+    priced_cost_basis = sum(
+        pos["total_cost_basis"] or 0 for pos in positions if pos["market_value"] is not None
+    )
+    market_value = sum(pos["market_value"] or 0 for pos in positions)
+    gain = sum(pos["gain"] or 0 for pos in positions)
+    day_change_value = sum(pos["day_change_value"] or 0 for pos in positions)
+    previous_market_value = market_value - day_change_value
+
+    return {
+        "total_cost_basis": _json_number(total_cost_basis),
+        "market_value": _json_number(market_value),
+        "gain": _json_number(gain),
+        "gain_pct": _json_number(_pct(gain, priced_cost_basis)),
+        "day_change_pct": _json_number(_pct(day_change_value, previous_market_value)),
+        "day_change_value": _json_number(day_change_value),
+        "position_count": len(positions),
+        "transaction_count": transaction_count,
+    }
+
+
+def _allocations(positions: list[dict[str, Any]], group_by: str) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    total_market_value = sum(pos["market_value"] or 0 for pos in positions)
+
+    for pos in positions:
+        key = pos["ticker"] if group_by == "ticker" else pos.get(group_by) or "Unspecified"
+        if key not in grouped:
+            grouped[key] = {
+                "key": key,
+                "total_cost_basis": 0.0,
+                "market_value": 0.0,
+                "position_count": 0,
+            }
+        grouped[key]["total_cost_basis"] += pos["total_cost_basis"] or 0
+        grouped[key]["market_value"] += pos["market_value"] or 0
+        grouped[key]["position_count"] += 1
+
+    allocations = []
+    for item in grouped.values():
+        market_value = item["market_value"]
+        allocations.append(
+            {
+                "key": item["key"],
+                "total_cost_basis": _json_number(item["total_cost_basis"]),
+                "market_value": _json_number(market_value),
+                "allocation_pct": _json_number(_pct(market_value, total_market_value)),
+                "position_count": item["position_count"],
+            }
+        )
+
+    allocations.sort(key=lambda item: item["market_value"], reverse=True)
+    return allocations
+
+
+def _transaction_view(tx: dict[str, Any]) -> dict[str, Any]:
+    return {key: tx.get(key) for key in TRANSACTION_KEYS}
+
+
+def _historical_change(
+    current_price: float | None,
+    historical_prices: dict[str, dict[str, float]],
+    ticker: str,
+    period: str,
+) -> float | None:
+    historical_price = historical_prices.get(ticker, {}).get(period)
+    if current_price is None or not historical_price:
+        return None
+    return _json_number(_pct(current_price - historical_price, historical_price))
+
+
+def _day_change_value(market_value: float, day_change_decimal: float | None) -> float | None:
+    if day_change_decimal is None or day_change_decimal == -1:
+        return None
+    return _json_number(market_value * day_change_decimal / (1 + day_change_decimal))
+
+
+def _representative_value(rows: list[dict[str, Any]], key: str) -> str | None:
+    values = [row.get(key) for row in rows if row.get(key)]
+    if not values:
+        return None
+
+    counts = Counter(values)
+    max_count = max(counts.values())
+    candidates = {value for value, count in counts.items() if count == max_count}
+    for row in sorted(rows, key=_row_sort_key, reverse=True):
+        value = row.get(key)
+        if value in candidates:
+            return value
+    return values[-1]
+
+
+def _min_date(rows: list[dict[str, Any]]) -> str | None:
+    dates = [row["date"] for row in rows if row.get("date")]
+    return min(dates) if dates else None
+
+
+def _max_date(rows: list[dict[str, Any]]) -> str | None:
+    dates = [row["date"] for row in rows if row.get("date")]
+    return max(dates) if dates else None
+
+
+def _row_sort_key(row: dict[str, Any]) -> tuple[str, int]:
+    return (row.get("date") or "", row.get("row_number") or 0)
+
+
+def _matches(value: str | None, filter_value: str | None, ticker: bool = False) -> bool:
+    if filter_value is None or filter_value == "":
+        return True
+    if ticker:
+        return (value or "").upper() == _normalize_ticker(filter_value)
+    return (value or "").casefold() == str(filter_value).strip().casefold()
+
+
+def _parse_filter_date(value: str | None, field_name: str, warnings: list[str]) -> str | None:
+    if not value:
+        return None
+    parsed = pd.to_datetime(value, errors="coerce")
+    if pd.isna(parsed):
+        warnings.append(f"Ignoring invalid {field_name}: {value}.")
+        return None
+    return parsed.date().isoformat()
+
+
+def _normalize_date(
+    value: Any,
+    worksheet_name: str,
+    row_number: int | None,
+    warnings: list[str],
+) -> str | None:
+    if _is_blank(value):
+        return None
+    parsed = pd.to_datetime(value, errors="coerce")
+    if pd.isna(parsed):
+        warnings.append(f"{worksheet_name} row {row_number} has an invalid date: {value}.")
+        return None
+    return parsed.date().isoformat()
+
+
+def _normalize_number(
+    value: Any,
+    column: str,
+    worksheet_name: str,
+    row_number: int | None,
+    warnings: list[str],
+) -> float:
+    if _is_blank(value):
+        warnings.append(f"{worksheet_name} row {row_number} has a blank {column}; using 0.")
+        return 0.0
+    cleaned = str(value).replace("$", "").replace(",", "").strip()
+    parsed = pd.to_numeric(cleaned, errors="coerce")
+    if pd.isna(parsed):
+        warnings.append(f"{worksheet_name} row {row_number} has invalid {column}: {value}; using 0.")
+        return 0.0
+    return float(parsed)
+
+
+def _normalize_ticker(value: Any) -> str:
+    cleaned = _clean_string(value)
+    return cleaned.upper() if cleaned else ""
+
+
+def _clean_header(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _clean_string(value: Any) -> str | None:
+    if _is_blank(value):
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
+def _is_blank(value: Any) -> bool:
+    return value is None or (isinstance(value, float) and pd.isna(value)) or str(value).strip() == ""
+
+
+def _divide(numerator: float, denominator: float) -> float | None:
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def _pct(numerator: float | None, denominator: float | None) -> float | None:
+    if numerator is None or not denominator:
+        return None
+    return 100 * numerator / denominator
+
+
+def _json_number(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if pd.isna(parsed):
+        return None
+    return parsed
+
+
+def _unique_warnings(warnings: list[str]) -> list[str]:
+    return list(dict.fromkeys(warning for warning in warnings if warning))

--- a/src/portfolio_data.py
+++ b/src/portfolio_data.py
@@ -189,7 +189,12 @@ def get_positions(
     }
 
 
-def get_position_detail(ticker: str, include_closed_history: bool = True) -> dict[str, Any]:
+def get_position_detail(
+    ticker: str,
+    include_closed_positions: bool = True,
+    include_raw_transactions: bool = False,
+    include_aggregate: bool = True,
+) -> dict[str, Any]:
     normalized_ticker = _normalize_ticker(ticker)
     warnings: list[str] = []
     positions_result = get_positions(ticker=normalized_ticker)
@@ -199,24 +204,34 @@ def get_position_detail(ticker: str, include_closed_history: bool = True) -> dic
     open_transactions_result = get_transactions(source=SOURCE_OPEN, ticker=normalized_ticker)
     warnings.extend(open_transactions_result["warnings"])
 
+    closed_positions: list[dict[str, Any]] = []
     closed_transactions: list[dict[str, Any]] = []
-    realized_position = None
-    if include_closed_history:
+    aggregate_realized_position = None
+
+    if include_closed_positions or include_aggregate:
+        realized_result = get_realized_positions(
+            ticker=normalized_ticker,
+            include_aggregate=include_aggregate,
+        )
+        warnings.extend(realized_result["warnings"])
+        if include_closed_positions:
+            closed_positions = realized_result["closed_positions"]
+        aggregate_positions = realized_result.get("aggregate_realized_positions") or []
+        if aggregate_positions:
+            aggregate_realized_position = aggregate_positions[0]
+
+    if include_raw_transactions:
         closed_transactions_result = get_transactions(source=SOURCE_CLOSED, ticker=normalized_ticker)
         warnings.extend(closed_transactions_result["warnings"])
         closed_transactions = closed_transactions_result["transactions"]
-
-        realized_result = get_realized_positions(ticker=normalized_ticker)
-        warnings.extend(realized_result["warnings"])
-        if realized_result["realized_positions"]:
-            realized_position = realized_result["realized_positions"][0]
 
     return {
         "ticker": normalized_ticker,
         "open_position": open_position,
         "open_transactions": open_transactions_result["transactions"],
+        "closed_positions": closed_positions,
         "closed_transactions": closed_transactions,
-        "realized_position": realized_position,
+        "aggregate_realized_position": aggregate_realized_position,
         "warnings": _unique_warnings(warnings),
     }
 
@@ -292,61 +307,192 @@ def get_transactions(
     }
 
 
-def get_realized_positions(ticker: str | None = None) -> dict[str, Any]:
+def get_realized_positions(
+    ticker: str | None = None,
+    include_aggregate: bool = True,
+) -> dict[str, Any]:
     loaded = load_sell_transactions()
     warnings = list(loaded["warnings"])
     normalized_ticker = _normalize_ticker(ticker) if ticker else None
-    transactions = [
-        tx
-        for tx in loaded["transactions"]
-        if normalized_ticker is None or tx["ticker"] == normalized_ticker
-    ]
+    transactions = sorted(loaded["transactions"], key=lambda tx: tx["row_number"] or 0)
+    closed_positions, match_warnings = _closed_positions_from_sell_transactions(
+        transactions,
+        target_ticker=normalized_ticker,
+    )
+    warnings.extend(match_warnings)
 
-    by_ticker: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    for tx in transactions:
-        by_ticker[tx["ticker"]].append(tx)
-
-    realized_positions = []
-    for tx_ticker in sorted(by_ticker):
-        rows = by_ticker[tx_ticker]
-        buy_rows = [tx for tx in rows if tx["action"] == "Buy"]
-        sell_rows = [tx for tx in rows if tx["action"] == "Sell"]
-
-        qty_bought = sum(tx["qty"] for tx in buy_rows)
-        qty_sold = sum(tx["qty"] for tx in sell_rows)
-        cost_basis = sum(tx["total"] for tx in buy_rows)
-        proceeds = sum(tx["total"] for tx in sell_rows)
-        realized_gain = proceeds - cost_basis
-        is_quantity_matched = abs(qty_bought - qty_sold) < 0.000001
-
-        if not is_quantity_matched:
-            warnings.append(
-                f"Sell tab quantity mismatch for {tx_ticker}: bought {qty_bought}, sold {qty_sold}."
-            )
-
-        realized_positions.append(
-            {
-                "ticker": tx_ticker,
-                "company": _representative_value(rows, "company"),
-                "category": _representative_value(rows, "category"),
-                "qty_bought": _json_number(qty_bought),
-                "qty_sold": _json_number(qty_sold),
-                "is_quantity_matched": is_quantity_matched,
-                "cost_basis": _json_number(cost_basis),
-                "proceeds": _json_number(proceeds),
-                "realized_gain": _json_number(realized_gain),
-                "realized_gain_pct": _json_number(_pct(realized_gain, cost_basis)),
-                "first_buy_date": _min_date(buy_rows),
-                "last_sell_date": _max_date(sell_rows),
-                "transaction_count": len(rows),
-            }
-        )
+    aggregate_realized_positions = (
+        _aggregate_realized_positions(closed_positions) if include_aggregate else None
+    )
 
     return {
         "source": "sell_tab",
-        "realized_positions": realized_positions,
+        "closed_positions": closed_positions,
+        "aggregate_realized_positions": aggregate_realized_positions,
         "warnings": _unique_warnings(warnings),
     }
+
+
+def _closed_positions_from_sell_transactions(
+    transactions: list[dict[str, Any]],
+    target_ticker: str | None = None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    warnings: list[str] = []
+    closed_positions: list[dict[str, Any]] = []
+    sequence_by_ticker: dict[str, int] = defaultdict(int)
+
+    for index, tx in enumerate(transactions):
+        if tx["action"] != "Sell":
+            continue
+        if target_ticker and tx["ticker"] != target_ticker:
+            continue
+
+        ticker = tx["ticker"]
+        sequence_by_ticker[ticker] += 1
+        qty_remaining = tx["qty"]
+        qty_bought = 0.0
+        cost_basis = 0.0
+        consumed_lots: list[dict[str, Any]] = []
+        buy_row_numbers: list[int] = []
+
+        for candidate in transactions[index + 1 :]:
+            if qty_remaining <= 0.000001:
+                break
+            if candidate["action"] == "Sell":
+                break
+            if candidate["ticker"] != ticker:
+                continue
+
+            available_qty = candidate["qty"]
+            if available_qty <= 0:
+                continue
+
+            consumed_qty = min(available_qty, qty_remaining)
+            lot_cost = candidate["total"] * consumed_qty / available_qty
+
+            qty_remaining -= consumed_qty
+            qty_bought += consumed_qty
+            cost_basis += lot_cost
+            consumed_lots.append(candidate)
+
+            row_number = candidate.get("row_number")
+            if row_number is not None and row_number not in buy_row_numbers:
+                buy_row_numbers.append(row_number)
+
+        is_quantity_matched = abs(qty_bought - tx["qty"]) < 0.000001
+        if not is_quantity_matched:
+            warnings.append(
+                f"Sell tab row {tx.get('row_number')} for {ticker} sold {tx['qty']} shares "
+                f"but only {qty_bought} following Buy shares were available before the next Sell row."
+            )
+
+        proceeds = tx["total"]
+        realized_gain = proceeds - cost_basis
+        closed_positions.append(
+            {
+                "closed_position_id": f"{ticker}-{tx.get('row_number') or sequence_by_ticker[ticker]}",
+                "ticker": ticker,
+                "company": tx.get("company") or _representative_value(consumed_lots, "company"),
+                "category": tx.get("category") or _representative_value(consumed_lots, "category"),
+                "close_date": tx.get("date"),
+                "qty_bought": _json_number(qty_bought) or 0,
+                "qty_sold": _json_number(tx["qty"]) or 0,
+                "is_quantity_matched": is_quantity_matched,
+                "cost_basis": _json_number(cost_basis) or 0,
+                "proceeds": _json_number(proceeds) or 0,
+                "average_cost": _json_number(_divide(cost_basis, qty_bought)),
+                "sell_price": _json_number(tx["price_per_share"]),
+                "average_sell_price": _json_number(_divide(proceeds, tx["qty"])),
+                "realized_gain": _json_number(realized_gain) or 0,
+                "realized_gain_pct": _json_number(_pct(realized_gain, cost_basis)),
+                "first_buy_date": _min_date(consumed_lots),
+                "buy_transaction_count": len(buy_row_numbers),
+                "buy_row_numbers": buy_row_numbers,
+                "sell_row_number": tx.get("row_number"),
+            }
+        )
+
+    closed_positions.sort(
+        key=lambda position: (
+            position["close_date"] is None,
+            position["close_date"] or "",
+            position["sell_row_number"] or 0,
+        )
+    )
+    return closed_positions, warnings
+
+
+def _aggregate_realized_positions(
+    closed_positions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    row_sets: dict[str, set[int]] = defaultdict(set)
+
+    for position in closed_positions:
+        ticker = position["ticker"]
+        if ticker not in grouped:
+            grouped[ticker] = {
+                "ticker": ticker,
+                "company": position.get("company"),
+                "category": position.get("category"),
+                "qty_bought": 0.0,
+                "qty_sold": 0.0,
+                "is_quantity_matched": True,
+                "cost_basis": 0.0,
+                "proceeds": 0.0,
+                "realized_gain": 0.0,
+                "first_buy_date": None,
+                "last_sell_date": None,
+            }
+
+        aggregate = grouped[ticker]
+        aggregate["company"] = aggregate["company"] or position.get("company")
+        aggregate["category"] = aggregate["category"] or position.get("category")
+        aggregate["qty_bought"] += position["qty_bought"] or 0
+        aggregate["qty_sold"] += position["qty_sold"] or 0
+        aggregate["is_quantity_matched"] = (
+            aggregate["is_quantity_matched"] and position["is_quantity_matched"]
+        )
+        aggregate["cost_basis"] += position["cost_basis"] or 0
+        aggregate["proceeds"] += position["proceeds"] or 0
+        aggregate["realized_gain"] += position["realized_gain"] or 0
+        aggregate["first_buy_date"] = _earliest(
+            aggregate["first_buy_date"],
+            position.get("first_buy_date"),
+        )
+        aggregate["last_sell_date"] = _latest(
+            aggregate["last_sell_date"],
+            position.get("close_date"),
+        )
+
+        for row_number in position.get("buy_row_numbers", []):
+            row_sets[ticker].add(row_number)
+        if position.get("sell_row_number") is not None:
+            row_sets[ticker].add(position["sell_row_number"])
+
+    aggregates = []
+    for ticker in sorted(grouped):
+        aggregate = grouped[ticker]
+        cost_basis = aggregate["cost_basis"]
+        aggregates.append(
+            {
+                "ticker": aggregate["ticker"],
+                "company": aggregate["company"],
+                "category": aggregate["category"],
+                "qty_bought": _json_number(aggregate["qty_bought"]) or 0,
+                "qty_sold": _json_number(aggregate["qty_sold"]) or 0,
+                "is_quantity_matched": aggregate["is_quantity_matched"],
+                "cost_basis": _json_number(cost_basis) or 0,
+                "proceeds": _json_number(aggregate["proceeds"]) or 0,
+                "realized_gain": _json_number(aggregate["realized_gain"]) or 0,
+                "realized_gain_pct": _json_number(_pct(aggregate["realized_gain"], cost_basis)),
+                "first_buy_date": aggregate["first_buy_date"],
+                "last_sell_date": aggregate["last_sell_date"],
+                "transaction_count": len(row_sets[ticker]),
+            }
+        )
+
+    return aggregates
 
 
 def _load_tab(
@@ -599,6 +745,16 @@ def _max_date(rows: list[dict[str, Any]]) -> str | None:
 
 def _row_sort_key(row: dict[str, Any]) -> tuple[str, int]:
     return (row.get("date") or "", row.get("row_number") or 0)
+
+
+def _earliest(first: str | None, second: str | None) -> str | None:
+    dates = [value for value in [first, second] if value]
+    return min(dates) if dates else None
+
+
+def _latest(first: str | None, second: str | None) -> str | None:
+    dates = [value for value in [first, second] if value]
+    return max(dates) if dates else None
 
 
 def _matches(value: str | None, filter_value: str | None, ticker: bool = False) -> bool:

--- a/src/util/gspread.py
+++ b/src/util/gspread.py
@@ -9,12 +9,21 @@ from src.config.ColumnNameConsts import ColumnNames as CN
 import gspread
 import pandas as pd
 from dotenv import load_dotenv
+from google.oauth2.service_account import Credentials
 
 CONFIG_DIR = "../../config"
 
 load_dotenv()
 
 def load_gspread():
+    service_account_file = os.getenv("GOOGLE_SERVICE_ACCOUNT_FILE")
+    if service_account_file:
+        credentials = Credentials.from_service_account_file(
+            service_account_file,
+            scopes=["https://www.googleapis.com/auth/spreadsheets"],
+        )
+        return gspread.authorize(credentials)
+
     cur_dir = os.path.dirname(os.path.realpath(__file__))
     credentials_file = os.path.join(cur_dir, CONFIG_DIR, "credentials.json")
     authorized_user_file = os.path.join(cur_dir, CONFIG_DIR, "authorized_user.json")
@@ -41,15 +50,29 @@ def load_gspread():
     return gc
 
 
-def transactions(sheet_id=None):
+def worksheet_values(sheet_id=None, worksheet_name=None, worksheet_index=0):
     if not sheet_id:
         sheet_id = os.getenv("TRANSACTIONS_SHEET")
 
     gc = load_gspread()
     sh = gc.open_by_key(sheet_id)
-    worksheet = sh.get_worksheet(0)
+
+    if worksheet_name:
+        try:
+            worksheet = sh.worksheet(worksheet_name)
+        except gspread.WorksheetNotFound:
+            if worksheet_index is None:
+                raise
+            worksheet = sh.get_worksheet(worksheet_index)
+    else:
+        worksheet = sh.get_worksheet(worksheet_index)
 
     data = worksheet.get_all_values()
+    return data
+
+
+def transactions(sheet_id=None, worksheet_name=None, worksheet_index=0):
+    data = worksheet_values(sheet_id, worksheet_name, worksheet_index)
     df = pd.DataFrame(data[1:], columns=data[0])
     df["Date"] = pd.to_datetime(df["Date"])
 

--- a/src/util/historical_cache.py
+++ b/src/util/historical_cache.py
@@ -1,8 +1,11 @@
 
 import datetime
+import logging
 import yfinance as yf
 import pandas as pd
 from typing import List, Dict, Optional
+
+logger = logging.getLogger(__name__)
 
 _price_cache: Dict[str, Dict[str, float]] = {}
 _cache_date: Optional[datetime.date] = None
@@ -26,7 +29,7 @@ def get_historical_prices(tickers: List[str]) -> Dict[str, Dict[str, float]]:
     missing_tickers = [t for t in tickers if t not in _price_cache]
     
     if missing_tickers:
-        print(f"Fetching historical data for: {missing_tickers}")
+        logger.info("Fetching historical data for: %s", missing_tickers)
         _fetch_and_cache_prices(missing_tickers)
         
     # Return requested tickers from cache
@@ -42,7 +45,14 @@ def _fetch_and_cache_prices(tickers: List[str]):
     try:
         # Fetch 1 year of data
         # auto_adjust=True ensures we get split/dividend adjusted prices (usually in 'Close')
-        data = yf.download(tickers, period="1y", group_by='ticker', auto_adjust=True, threads=True)
+        data = yf.download(
+            tickers,
+            period="1y",
+            group_by='ticker',
+            auto_adjust=True,
+            threads=True,
+            progress=False,
+        )
         
         if data.empty:
             for t in tickers:
@@ -76,8 +86,8 @@ def _fetch_and_cache_prices(tickers: List[str]):
                 else:
                     _price_cache[t] = {}
                     
-    except Exception as e:
-        print(f"Error fetching historical prices: {e}")
+    except Exception:
+        logger.exception("Error fetching historical prices")
         # Prevent partial failures from blocking future attempts? 
         # Or mark failed tickers as empty to avoid retry?
         for t in tickers:

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,9 @@ source = { editable = "." }
 dependencies = [
     { name = "flask" },
     { name = "gspread" },
+    { name = "mcp", extra = ["cli"] },
     { name = "pandas" },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "python-dotenv" },
     { name = "yfinance" },
@@ -19,10 +21,51 @@ dependencies = [
 requires-dist = [
     { name = "flask", specifier = ">=3.1.0" },
     { name = "gspread", specifier = ">=6.2.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.27.2" },
     { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "yfinance", specifier = ">=0.2.66" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -173,6 +216,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
 name = "curl-cffi"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -262,6 +358,52 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -298,6 +440,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -350,6 +531,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -538,12 +759,111 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -584,12 +904,47 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -621,6 +976,114 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]
+
+[[package]]
 name = "rsa"
 version = "4.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -630,6 +1093,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -651,12 +1123,64 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d3/90c1ee19209cb59f6ad185883fd4ccfcf72f8f0bfd549d5a8b70474611d0/typer-0.26.4.tar.gz", hash = "sha256:25b128964de66c5ea36d5ac82adc579e5e113509b17469edf9f5a4a1864ff2a9", size = 201191, upload-time = "2026-05-30T17:05:04.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl", hash = "sha256:11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6", size = 122436, upload-time = "2026-05-30T17:05:05.812Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
@@ -675,6 +1199,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a read-only MCP server for portfolio holdings, transactions, and realized-position summaries. Refactors the Flask dashboard to reuse the shared portfolio data layer and documents Claude/ChatGPT setup.